### PR TITLE
Fix apply configmap timeout error

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -83,9 +83,10 @@ resource "null_resource" "apply_configmap_auth" {
 
   provisioner "local-exec" {
     command = <<EOT
-      while [[ ! -e ${local.configmap_auth_file} ]] ; do sleep 1; done && \
-      aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} && \
-      kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path}
-    EOT
+until $(ls ${local.configmap_auth_file} > /dev/null 2>&1); do sleep 1; done && \
+aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} && \
+until $(kubectl get nodes --kubeconfig=${var.kubeconfig_path} > /dev/null 2>&1); do sleep 1; done && \
+kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path}
+EOT
   }
 }


### PR DESCRIPTION
This PR implements a fix for the timeout error when applying the `aws-auth-configmap`.

```
Error: Error running command '      while [[ ! -e .terraform/modules/eks_cluster/configmap-auth.yaml ]] ; do sleep 1; done && \
      aws eks update-kubeconfig --name=eg-dev-eks-cluster --region=us-east-1 --kubeconfig=kubeconfig.yaml && \
      kubectl apply -f .terraform/modules/eks_cluster/configmap-auth.yaml --kubeconfig kubeconfig.yaml
': exit status 1. Output: /bin/sh: 1: [[: not found
Added new context arn:aws:eks:us-east-1:318271710090:cluster/eg-dev-eks-cluster to /code/terraform/templates/services/eks-cluster/kubeconfig.yaml
error: unable to recognize ".terraform/modules/eks_cluster/configmap-auth.yaml": Get https://57D309AE3D9B2D130A87D9EC78BDEE24.gr7.us-east-1.eks.amazonaws.com/api?timeout=32s: dial tcp 54.208.191.56:443: i/o timeout
```